### PR TITLE
Use constraints for width value

### DIFF
--- a/Tweak.mm
+++ b/Tweak.mm
@@ -47,12 +47,12 @@ static void hook_ZBPackageListTableViewController_viewDidAppear(ZBPackageListTab
 	// if we're on the packages page (index 3) and stripeCount hasn't been made yet...
 	if(self.tabBarController.selectedIndex == 3 && !self.stripeCount){
 		// Create label
-		self.stripeCount = [[UILabel alloc] initWithFrame:CGRectZero];
+		self.stripeCount = [[UILabel alloc] init];
 		[self.view addSubview:self.stripeCount];
 
 		[self.stripeCount setTranslatesAutoresizingMaskIntoConstraints:NO];
 		[self.stripeCount.heightAnchor constraintEqualToConstant:20].active = YES;
-		[self.stripeCount.widthAnchor constraintEqualToConstant:self.view.bounds.size.width].active = YES;
+		[self.stripeCount.widthAnchor constraintEqualToAnchor:self.view.window.widthAnchor].active = YES;
 		[self.stripeCount.topAnchor constraintEqualToAnchor:self.view.topAnchor constant:-12].active = YES;
 
 		// RTL Support


### PR DESCRIPTION
Hey, what's up? Anyways here's a small PR which doesn't change functionality but some code logic:
 
- First it's not necessary to write `initWithFrame` and pass a value, even though in this case it's just `CGRectZero`. When setting the constraints property to `NO;` whatever value there will just get ignored and the constraints that you manually specified will take effect. You could even use `[UILabel new];` if you wanted to, but that's just preference haha.

- I changed the width constraint since it's not actually being a constraint but a "frame", constraining to the view's bounds doesn't provide landscape support, even though here it makes no difference, but ig for the sake of good practices. (cc: RuntimeOverflow, he told me this for another tweak I'm making).

Also I noticed you use left and right anchors and use an if/else statement to provide RTL support. Leading and trailing already do this apparently so you could use that. I did not modify that part though because I'm not sure if you want it or not.

I forgot to mention that thank you for making this no Logos version, I learnt how to make full Substrate tweaks recently and was struggling on how to use the equivalent of `%new;` and I happened to find this blessed repository haha, anyways, hope you're doing well, and thanks again!